### PR TITLE
Fix overwrite of ffmpeg_path

### DIFF
--- a/src/classes/Settings.php
+++ b/src/classes/Settings.php
@@ -326,7 +326,7 @@ class Settings extends Page
 			/*** Image ***/
 			Settings::$rotate_image	=	isset($admin_settings['rotate_image']);
 			if(isset($admin_settings['exiftran_path'])){
-				Settings::$ffmpeg_path	=	$admin_settings['exiftran_path'];
+				Settings::$exiftran_path	=	$admin_settings['exiftran_path'];
 			}
 		}
 


### PR DESCRIPTION
Maybe simply by copying, but a stored exiftran_path overwrites the ffmpeg_path on load of Settings. Fixed